### PR TITLE
use the company name for the logo image alt text

### DIFF
--- a/AnalogSea_SignUpPage.html
+++ b/AnalogSea_SignUpPage.html
@@ -9,7 +9,7 @@
 	<div class="container">
 
 		<div class="logoClass">
-			<img src="images/logo.png" alt="company logo">
+			<img src="images/logo.png" alt="AnalogSea">
 		</div>
 
 		<div class="form-class">


### PR DESCRIPTION
Alt text is display/spoken when the image cannot be. We want to describe the purpose of the image, so normally don't want to say 'graphic' or 'image' or 'photo of'. For a company logo (which is often a link to the home page), just the company name is best.

More background: https://webaim.org/techniques/alttext/#logos