### PR TITLE
avoid prefixes

### DIFF
--- a/css/AnalogSea-SytlingSheet.css
+++ b/css/AnalogSea-SytlingSheet.css
@@ -53,9 +53,6 @@ button[type="submit"] {
 button[type="submit"]:hover,
 button[type="submit"]:focus {
   background-color: #0CB863;
-  -webkit-transition: background 0.1s;
-  -moz-transition: background 0.1s;
-  -o-transition: background 0.1s;
   transition: background 0.1s;
 }
 .login-link {


### PR DESCRIPTION
prefixes are an (older) way browsers expose features before they are fully implemented.

```css
-webkit-transition: background 0.1s;
-moz-transition: background 0.1s;
-o-transition: background 0.1s;
```

The above prefixes are for webkit (Safari, Chrome, Opera), mozilla (Firefox) and opera (really old Opera, before it switched to the blink rendering engine which would use the webkit prefix). These browsers all support transitions without requiring the prefix. You can quickly check browser support by searching `caniuse transitions` which will take you to this great site for front-end developers: https://caniuse.com/#feat=css-transitions

You can see there browser support is great, so we won't need prefixes here. We can talk more about when/why you might use them (and how to automate it when you do need them).

Having them doesn't do any harm, although can make you css file bigger than it needs to be and more of a nuisance to edit. To change the transition you'll have to edit multiple lines, instead of just one.